### PR TITLE
Fixed mutual inductive translation and added partial primitive records

### DIFF
--- a/src/ePlugin.ml
+++ b/src/ePlugin.ml
@@ -206,9 +206,9 @@ let primitives_from_declaration env (ind: Names.mutual_inductive) =
 
 let translate_inductive_gen f err translator (ind, _) =
   let env = Global.env () in
-  let (mind, _) = Inductive.lookup_mind_specif env (ind, 0) in
+  let (mind, _ as specif) = Inductive.lookup_mind_specif env (ind, 0) in
 
-  let primitive_records = EUtil.primitive_record mind in 
+  let primitive_records = Inductive.is_primitive_record specif in 
 
   let mind' = EUtil.process_inductive mind in
   let mind_ = f err translator env ind mind mind' in

--- a/src/ePlugin.ml
+++ b/src/ePlugin.ml
@@ -199,6 +199,7 @@ let ptranslate_constant err translator cst ids =
   [ExtConstant (cst, ConstRef cst_)]
 
 let primitives_from_declaration env (ind: Names.mutual_inductive) =
+  let open Declarations in 
   let (mind, _) = Inductive.lookup_mind_specif env (ind, 0) in  
   let (_, projs, _) = Option.get (Option.get mind.mind_record) in
   Array.to_list projs

--- a/src/eTranslate.ml
+++ b/src/eTranslate.ml
@@ -790,7 +790,7 @@ let abstract_mind sigma mind n k c =
     if m <= k then c
     else mkRel (k + m)
   | Ind ((ind, m), _) when MutInd.equal mind ind ->
-    mkRel (k + m + 1)
+    mkRel (k + n - m)
   | _ ->
     map_with_binders sigma succ aux k c
   in
@@ -798,8 +798,8 @@ let abstract_mind sigma mind n k c =
 
 let translate_constructors env sigma mind0 mind ind0 ind =
   let mutind, env = extend_inductive env mind0 mind in
-  let mk_ind n = mkInd (mutind, n) in
   let nblock = Array.length mind0.mind_packets in
+  let mk_ind n = mkInd (mutind, nblock - (n + 1)) in
   let subst0 = List.init nblock mk_ind in
   let map sigma t =
     (** A bit of term mangling: indices in the context referring to the
@@ -830,7 +830,7 @@ let translate_inductive_body env sigma mind0 mind n ind0 ind =
   in
   (** FIXME, probably wrong indices for mutual inductive blocks *)
   let (_, fail_args) = List.fold_left fail_arg (2, []) (Environ.rel_context arity_env.env_tgt) in
-  let n = 2 + n + Environ.nb_rel arity_env.env_tgt in
+  let n = 1 + (mind0.mind_ntypes - n) + Environ.nb_rel arity_env.env_tgt in
   let fail_case = applist (mkRel n, fail_args) in
   let fail_ctx = LocalAssum (Anonymous, mkRel (1 + List.length ind0.mind_arity_ctxt)) :: arity_ctx' in
   let fail_case = it_mkProd_or_LetIn fail_case fail_ctx in
@@ -892,8 +892,8 @@ let pextend_inductive env (mutind0, _) mind0 mind =
 
 let ptranslate_constructors env sigma mutind0 mind0 mind ind0 ind =
   let mutind, env = pextend_inductive env mutind0 mind0 mind in
-  let mk_ind n = mkInd (mutind, n) in
   let nblock = Array.length mind0.mind_packets in
+  let mk_ind n = mkInd (mutind, nblock - (n + 1)) in
   let subst0 = List.init nblock mk_ind in
   let map (n, sigma) t =
     (** A bit of term mangling: indices in the context referring to the

--- a/src/eTranslate.ml
+++ b/src/eTranslate.ml
@@ -968,7 +968,7 @@ let rec split_record_constr sigma term = match EConstr.kind sigma term with
       ty :: split_record_constr sigma bd
   | _ -> []                                                    
 
-let abstract_proj sigma mind n k c =
+let pabstract_proj sigma mind n k c =
   let rec aux k c = match EConstr.kind sigma c with
   | Rel m ->
     if m <= k then c
@@ -980,12 +980,12 @@ let abstract_proj sigma mind n k c =
   in
   aux k c
 
-let ptranslate_primitive_projections env sigma mutind mind_d mind_e ind_e =
+let ptranslate_primitive_projections env sigma mutind ext_mindx mind_d mind_e ind_e =
   let record_constructor = EConstr.of_constr (List.hd ind_e.mind_entry_lc) in
   let projections = split_record_constr sigma record_constructor in
   let nparams = List.length mind_e.mind_entry_params in
-  let mk_ind n = mkInd (mutind, nparams + n) in
-  let subst_ind = List.init nparams (fun i -> mkVar (Names.Id.of_string ("s"^(string_of_int i))))(*mk_ind i*) in  
+  let mk_ind n = mkInd (mutind, 1) in
+  let subst_ind = List.init nparams (fun i -> mk_ind i) in  
   let () = Feedback.msg_info (Pp.str "Now Checking") in
   let map (n, sigma) t =
     let t = Vars.substnl subst_ind (n - 1) t in 
@@ -997,7 +997,7 @@ let ptranslate_primitive_projections env sigma mutind mind_d mind_e ind_e =
   
 
 let ptranslate_primitive_record env sigma mutind mind_d mind_e =
-  let _, env = pextend_inductive env (mutind, 0) mind_d mind_e in
+  let ext_mind, env = pextend_inductive env (mutind, 0) mind_d mind_e in
   let ind_e = List.hd mind_e.mind_entry_inds in 
   let ind_d = mind_d.mind_packets.(0) in 
   let ind_name = ptranslate_internal_name ind_e.mind_entry_typename in
@@ -1008,7 +1008,7 @@ let ptranslate_primitive_record env sigma mutind mind_d mind_e =
   let () = Feedback.msg_info (Pp.str "constructor") in
   let con = (List.hd ind_e.mind_entry_lc) in
   let () = Feedback.msg_info (Printer.pr_constr con) in
-  let _ = ptranslate_primitive_projections env sigma mutind mind_d mind_e ind_e in
+  let _ = ptranslate_primitive_projections env sigma mutind ext_mind mind_d mind_e ind_e in
   let () = assert false in
   (*
   let (sigma, constr_type) = ptranslate_constructors env sigma mutind mind_d mind_e ind_d ind_e in

--- a/src/eTranslate.ml
+++ b/src/eTranslate.ml
@@ -557,8 +557,6 @@ let rec optranslate env sigma c0 = match EConstr.kind sigma c0 with
       let specif = Inductive.lookup_mind_specif env.penv_ptgt ind in 
       let primitive = Inductive.is_primitive_record specif in 
       let args = Inductive.inductive_params specif in
-      let () = Feedback.msg_info (Pp.str "params ---> " ++ Pp.int args) in
-      let () = Feedback.msg_info (Pp.str "prim ---> " ++ Pp.bool primitive) in
       (primitive, args)
     else
       (false, 0)
@@ -571,13 +569,10 @@ let rec optranslate env sigma c0 = match EConstr.kind sigma c0 with
     let (sigma, tr) = optranslate env sigma t in
     let arg = tr :: accu in 
     let arg = 
-      if primitive then
-        if params < i then 
+      if primitive && params < i then 
           arg
-        else if params == i then 
+      else if primitive &&  params == i then 
           te :: arg
-        else 
-          t_ :: arg 
       else
         t_ :: arg
     in

--- a/src/eUtil.ml
+++ b/src/eUtil.ml
@@ -238,3 +238,8 @@ let process_inductive mib =
     mind_entry_private = mib.mind_private;
     mind_entry_universes = ind_univs
   }
+
+let primitive_record mind = 
+  match mind.mind_record with
+  | Some (Some _) -> true
+  | _ -> false

--- a/src/eUtil.mli
+++ b/src/eUtil.mli
@@ -9,3 +9,5 @@ val retype_inductive :
   evar_map * one_inductive_entry list * Context.Rel.t
 
 val process_inductive : mutual_inductive_body -> mutual_inductive_entry
+
+val primitive_record : mutual_inductive_body -> bool

--- a/tests/mutual_inductive_translation.v
+++ b/tests/mutual_inductive_translation.v
@@ -1,0 +1,30 @@
+Require Import Effects.Effects.
+
+Effect Translate nat. Parametricity Translate nat.
+
+Inductive even: nat -> Prop :=
+| evZ: even 0
+| evS: forall n, odd n -> even (S n)
+with
+odd: nat -> Prop :=
+| oddS: forall n, even n -> odd (S n).
+
+Effect Translate even. Parametricity Translate even.
+
+Inductive mTest1: Prop :=
+| cmTest11: mTest1
+| cmTest12: mTest1 -> mTest3 -> mTest2 -> mTest1
+| cmTest13: mTest2 -> mTest1
+with
+mTest2: Prop :=
+| cmTest21: mTest1 -> mTest2
+with
+mTest3: Prop :=
+| cmTest31: mTest1 -> mTest2 -> mTest3
+with
+mTest4: Prop :=
+| cmTest41: mTest4
+| cmTest42: mTest1 -> mTest2 -> mTest3 -> mTest4 -> mTest4.
+
+Effect Translate mTest2. Parametricity Translate mTest4.
+Print mTest4ᴿ.

--- a/tests/primitive_record.v
+++ b/tests/primitive_record.v
@@ -4,87 +4,52 @@ Require Import Effects.Effects.
 Effect Translate eq.
 Effect Translate nat.
 Effect Translate bool.
-Effect Translate sigT.
 
 Parametricity Translate eq.
 Parametricity Translate nat.
 Parametricity Translate bool.
-Parametricity Translate sigT.
-
-Effect Translate ex.
-Parametricity Translate ex. Print exᴿ.
-
-Definition g (A: Type) (B: A -> Type): A -> Type := fun _ => Type.
-Effect Translate g.
-Parametricity Translate g. Print gᴿ.
-
-Record tsigR (A: Type) (B: A -> Type): Type := texR {
-  tzero: A -> Type;
-  tfst: A;
-  tsnd: B tfst;
-  tthd: forall (x: B tfst), A -> x = tsnd;
-  tfth: tzero tfst;
-}.
-Print tsigR.
-Effect Translate tsigR. Print tsigRᵒ.
-Parametricity Translate tsigR. Print tsigRᴿ.
 
 Set Primitive Projections.
+Record recordTest (A: Type) (B: A -> Type): Type := recordTestB {
+  c1: A -> Type;
+  c2: A;
+  c3: B c2;
+  c4: forall (x: B c2), A -> x = c3;
+  c5: c1 c2;
+}.
+Unset Primitive Projections.
+Effect Translate recordTest.
+Parametricity Translate recordTest.
+
 Record sigR (A: Type) (B: A -> Type): Type := exR {
-  zero: A -> Type;
   fst: A;
   snd: B fst;
-  thd: forall (x: B fst), A -> x = snd;
-  fth: zero fst;
 }.
-Effect Translate sigR. Print sigRᵒ.
-Parametricity Translate sigR. Print sigRᴿ.
+Effect Translate sigR.
+Parametricity Translate sigR.
 
-Record ss (A: Type) (B: A -> Type): Type := sexR {
-  sfst: A;
-  ssnd: B sfst;
-}.
-
-Effect Translate ss.
-Parametricity Translate ss. Check sexRᴿ.
-Print sigT.
-Definition gg A := @tsigR A.
-Effect Translate gg. Print ggᵉ.
-Parametricity Translate gg. Print ggᴿ.
-
-Definition tt: ss nat (fun n: nat => bool) := {|
-  sfst := 0 ;
-  ssnd := true ;
-|}.
-Print tt.
-Effect Translate tt. Check sexRᴿ.
-Parametricity Translate tt.
-
+(** Primitive record on body no handled yet.
+    Fail to find default exceptional for primitive record *)
+Definition fail_1 A B := sigR A B.
+Definition fail_2 A := sigR A.
+Definition fail_3 := sigR.
 (*
-Illegal application: 
-The term "sexRᴿ" of type
- "forall (E : Type) (A : El Typeᵉ) (Aᴿ : El A -> Type) (B : El A -> El Typeᵉ)
-    (Bᴿ : forall H : El A, Aᴿ H -> El (B H) -> Type) (r : ssᵒ E A B) (sfstᴿ : Aᴿ (sfstᵉ _ _ _ r)),
-  Bᴿ (sfstᵉ _ _ _ r) sfstᴿ (ssndᵉ _ _ _ r) -> ssᴿ E A Aᴿ B Bᴿ r"
-cannot be applied to the terms
- "E" : "Type"
- "TypeVal E (natᵒ E) (natᴱ E)" : "type E"
- "natᴿ E" : "natᵒ E -> Type"
- "fun _ : natᵒ E => TypeVal E (boolᵒ E) (boolᴱ E)" : "natᵒ E -> type E"
- "fun (n : natᵒ E) (_ : natᴿ E n) => boolᴿ E" : "forall n : natᵒ E, natᴿ E n -> boolᵒ E -> Type"
- "Oᵉ E" : "natᵒ E"
- "Oᴿ E" : "natᴿ E (Oᵉ E)"
- "trueᵉ E" : "boolᵒ E"
- "trueᴿ E" : "boolᴿ E (trueᵉ E)"
-The 6th term has type "natᵒ E" which should be coercible to
- "ssᵒ E (TypeVal E (natᵒ E) (natᴱ E)) (fun _ : natᵒ E => TypeVal E (boolᵒ E) (boolᴱ E))".
+Fail Effect Translate fail_1.
+Fail Effect Translate fail_2.
+Fail Effect Translate fail_3.
 *)
 
-Effect Translate tt.
-Definition f := snd nat (fun _ => bool) tt.
-Effect Translate f.
+Definition primitive_id: sigR nat (fun n: nat => bool) -> sigR nat (fun n: nat => bool) := fun a => a.
+Effect Translate primitive_id.
+Parametricity Translate primitive_id.
 
-CoInductive stream (A: Type) := Stream {
-  hd: A;
-  tl: stream A
-}.
+Definition test: sigR nat (fun n: nat => bool) := {|
+  fst := 0 ;
+  snd := true ;
+|}.
+Effect Translate test.
+Parametricity Translate test.
+
+Definition app_test := primitive_id test.
+Effect Translate app_test.
+Parametricity Translate app_test.

--- a/tests/primitive_record.v
+++ b/tests/primitive_record.v
@@ -16,7 +16,14 @@ Definition tt: sigR _ (fun _ => bool) := {|
   fst := 0 ;
   snd := true
 |}.
+Effect Translate tt.
+Parametricity Translate tt.
 
 Effect Translate tt.
 Definition f := snd nat (fun _ => bool) tt.
 Effect Translate f.
+
+CoInductive stream (A: Type) := Stream {
+  hd: A;
+  tl: stream A
+}. Print stream.  

--- a/tests/primitive_record.v
+++ b/tests/primitive_record.v
@@ -1,0 +1,22 @@
+
+Require Import Effects.Effects.
+
+Set Primitive Projections.
+
+Effect Translate nat.
+Effect Translate bool.
+
+Record sigR (A: Type) (B: A -> Type): Type := exR {
+  fst: A;
+  snd: B fst;
+}. 
+Effect Translate sigR.
+
+Definition tt: sigR _ (fun _ => bool) := {|
+  fst := 0 ;
+  snd := true
+|}.
+
+Effect Translate tt.
+Definition f := snd nat (fun _ => bool) tt.
+Effect Translate f.

--- a/tests/primitive_record.v
+++ b/tests/primitive_record.v
@@ -6,6 +6,7 @@ Effect Translate nat.
 Effect Translate bool.
 
 Parametricity Translate eq.
+Parametricity Translate nat.
 
 Effect Translate ex.
 Parametricity Translate ex. Print exᴿ.
@@ -25,6 +26,15 @@ Print tsigR.
 Effect Translate tsigR. Print tsigRᵒ.
 Parametricity Translate tsigR. Print tsigRᴿ.
 
+Definition a (A: Type) (B: A -> Type) (f: A) (snd: B f): snd = snd.
+Proof. reflexivity. Defined.
+Effect Translate a. Print aᵉ.
+Parametricity Translate a. Print aᴿ.
+
+Definition id (A: Type) : A -> A := fun a => a.
+Effect Translate id. Print idᵉ.
+Parametricity Translate id. Print idᴿ.
+
 Set Primitive Projections.
 Record sigR (A: Type) (B: A -> Type): Type := exR {
   zero: A -> Type;
@@ -32,9 +42,26 @@ Record sigR (A: Type) (B: A -> Type): Type := exR {
   snd: B fst;
   thd: forall (x: B fst), A -> x = snd;
   fth: zero fst;
-}. 
-Effect Translate sigR. Print sigR.
-Parametricity Translate sigR. Print sigRᴿ. 
+}.
+Effect Translate sigR. Print sigRᵒ.
+Parametricity Translate sigR. Print sigRᴿ.
+
+Record msigR (E: Type) (A: El Typeᵉ) 
+    (A': El A -> Type) 
+    (B: El A -> El Typeᵉ)
+    (B': forall H: @El E A, A' H -> @El E (B H) ->Type)
+    (r: sigRᵒ E A B) := {
+  mzero: forall H: @El E A, A' H -> @El E (zeroᵉ _ _ _ r H) -> Type;
+  mfst: A' (fstᵉ _ _ _ r);
+  msnd: B' (fstᵉ _ _ _ r) mfst (sndᵉ _ _ _ r);
+  mthd: forall (x: @El E (B (fstᵉ _ _ _ r)))
+               (x': B' (fstᵉ _ _ _ r) mfst x)
+               (a: @El E A)
+               (a': A' a),
+               eqᴿ E (B (fstᵉ _ _ _ r)) (B' (fstᵉ _ _ _ r) mfst)
+                   x x' (sndᵉ _ _ _ r) msnd (thdᵉ _ _ _ r x a);
+  mfth: mzero (fstᵉ _ _ _ r) mfst (fthᵉ _ _ _ r);
+}.
 
 Definition tt: sigR _ (fun _ => bool) := {|
   fst := 0 ;

--- a/tests/primitive_record.v
+++ b/tests/primitive_record.v
@@ -4,9 +4,12 @@ Require Import Effects.Effects.
 Effect Translate eq.
 Effect Translate nat.
 Effect Translate bool.
+Effect Translate sigT.
 
 Parametricity Translate eq.
 Parametricity Translate nat.
+Parametricity Translate bool.
+Parametricity Translate sigT.
 
 Effect Translate ex.
 Parametricity Translate ex. Print exᴿ.
@@ -26,15 +29,6 @@ Print tsigR.
 Effect Translate tsigR. Print tsigRᵒ.
 Parametricity Translate tsigR. Print tsigRᴿ.
 
-Definition a (A: Type) (B: A -> Type) (f: A) (snd: B f): snd = snd.
-Proof. reflexivity. Defined.
-Effect Translate a. Print aᵉ.
-Parametricity Translate a. Print aᴿ.
-
-Definition id (A: Type) : A -> A := fun a => a.
-Effect Translate id. Print idᵉ.
-Parametricity Translate id. Print idᴿ.
-
 Set Primitive Projections.
 Record sigR (A: Type) (B: A -> Type): Type := exR {
   zero: A -> Type;
@@ -46,29 +40,44 @@ Record sigR (A: Type) (B: A -> Type): Type := exR {
 Effect Translate sigR. Print sigRᵒ.
 Parametricity Translate sigR. Print sigRᴿ.
 
-Record msigR (E: Type) (A: El Typeᵉ) 
-    (A': El A -> Type) 
-    (B: El A -> El Typeᵉ)
-    (B': forall H: @El E A, A' H -> @El E (B H) ->Type)
-    (r: sigRᵒ E A B) := {
-  mzero: forall H: @El E A, A' H -> @El E (zeroᵉ _ _ _ r H) -> Type;
-  mfst: A' (fstᵉ _ _ _ r);
-  msnd: B' (fstᵉ _ _ _ r) mfst (sndᵉ _ _ _ r);
-  mthd: forall (x: @El E (B (fstᵉ _ _ _ r)))
-               (x': B' (fstᵉ _ _ _ r) mfst x)
-               (a: @El E A)
-               (a': A' a),
-               eqᴿ E (B (fstᵉ _ _ _ r)) (B' (fstᵉ _ _ _ r) mfst)
-                   x x' (sndᵉ _ _ _ r) msnd (thdᵉ _ _ _ r x a);
-  mfth: mzero (fstᵉ _ _ _ r) mfst (fthᵉ _ _ _ r);
+Record ss (A: Type) (B: A -> Type): Type := sexR {
+  sfst: A;
+  ssnd: B sfst;
 }.
 
-Definition tt: sigR _ (fun _ => bool) := {|
-  fst := 0 ;
-  snd := true
+Effect Translate ss.
+Parametricity Translate ss. Check sexRᴿ.
+Print sigT.
+Definition gg A := @sigT A.
+Effect Translate gg. Print ggᵉ.
+
+Definition tt: ss nat (fun n: nat => bool) := {|
+  sfst := 0 ;
+  ssnd := true ;
 |}.
+
 Effect Translate tt.
 Parametricity Translate tt.
+
+(*
+Illegal application: 
+The term "sexRᴿ" of type
+ "forall (E : Type) (A : El Typeᵉ) (Aᴿ : El A -> Type) (B : El A -> El Typeᵉ)
+    (Bᴿ : forall H : El A, Aᴿ H -> El (B H) -> Type) (r : ssᵒ E A B) (sfstᴿ : Aᴿ (sfstᵉ _ _ _ r)),
+  Bᴿ (sfstᵉ _ _ _ r) sfstᴿ (ssndᵉ _ _ _ r) -> ssᴿ E A Aᴿ B Bᴿ r"
+cannot be applied to the terms
+ "E" : "Type"
+ "TypeVal E (natᵒ E) (natᴱ E)" : "type E"
+ "natᴿ E" : "natᵒ E -> Type"
+ "fun _ : natᵒ E => TypeVal E (boolᵒ E) (boolᴱ E)" : "natᵒ E -> type E"
+ "fun (n : natᵒ E) (_ : natᴿ E n) => boolᴿ E" : "forall n : natᵒ E, natᴿ E n -> boolᵒ E -> Type"
+ "Oᵉ E" : "natᵒ E"
+ "Oᴿ E" : "natᴿ E (Oᵉ E)"
+ "trueᵉ E" : "boolᵒ E"
+ "trueᴿ E" : "boolᴿ E (trueᵉ E)"
+The 6th term has type "natᵒ E" which should be coercible to
+ "ssᵒ E (TypeVal E (natᵒ E) (natᴱ E)) (fun _ : natᵒ E => TypeVal E (boolᵒ E) (boolᴱ E))".
+*)
 
 Effect Translate tt.
 Definition f := snd nat (fun _ => bool) tt.
@@ -77,4 +86,4 @@ Effect Translate f.
 CoInductive stream (A: Type) := Stream {
   hd: A;
   tl: stream A
-}. Print stream.  
+}.

--- a/tests/primitive_record.v
+++ b/tests/primitive_record.v
@@ -48,15 +48,16 @@ Record ss (A: Type) (B: A -> Type): Type := sexR {
 Effect Translate ss.
 Parametricity Translate ss. Check sexRᴿ.
 Print sigT.
-Definition gg A := @sigT A.
+Definition gg A := @tsigR A.
 Effect Translate gg. Print ggᵉ.
+Parametricity Translate gg. Print ggᴿ.
 
 Definition tt: ss nat (fun n: nat => bool) := {|
   sfst := 0 ;
   ssnd := true ;
 |}.
-
-Effect Translate tt.
+Print tt.
+Effect Translate tt. Check sexRᴿ.
 Parametricity Translate tt.
 
 (*

--- a/tests/primitive_record.v
+++ b/tests/primitive_record.v
@@ -1,16 +1,40 @@
 
 Require Import Effects.Effects.
 
-Set Primitive Projections.
-
+Effect Translate eq.
 Effect Translate nat.
 Effect Translate bool.
 
+Parametricity Translate eq.
+
+Effect Translate ex.
+Parametricity Translate ex. Print exᴿ.
+
+Definition g (A: Type) (B: A -> Type): A -> Type := fun _ => Type.
+Effect Translate g.
+Parametricity Translate g. Print gᴿ.
+
+Record tsigR (A: Type) (B: A -> Type): Type := texR {
+  tzero: A -> Type;
+  tfst: A;
+  tsnd: B tfst;
+  tthd: forall (x: B tfst), A -> x = tsnd;
+  tfth: tzero tfst;
+}.
+Print tsigR.
+Effect Translate tsigR. Print tsigRᵒ.
+Parametricity Translate tsigR. Print tsigRᴿ.
+
+Set Primitive Projections.
 Record sigR (A: Type) (B: A -> Type): Type := exR {
+  zero: A -> Type;
   fst: A;
   snd: B fst;
+  thd: forall (x: B fst), A -> x = snd;
+  fth: zero fst;
 }. 
-Effect Translate sigR.
+Effect Translate sigR. Print sigR.
+Parametricity Translate sigR. Print sigRᴿ. 
 
 Definition tt: sigR _ (fun _ => bool) := {|
   fst := 0 ;


### PR DESCRIPTION
- Fixed problem with the indices: fail case always referenced first case of the inductive block and constructors referenced inverse inductive of the block.
- Added test for mutual inductives.
- Added primitive records in both layer, but the default exceptional constructor is missing (only affecting when inductives types are in the body of tersm).
- Added test for primitive records.