### PR TITLE
Generation of parametric induction principle

### DIFF
--- a/src/ePlugin.ml
+++ b/src/ePlugin.ml
@@ -331,6 +331,7 @@ let instantiate_parametric_modality err translator (name, n) ext =
     List.fold_map fold_map (0, translator) (Array.to_list D.(mind.mind_packets)) 
   in
   let env = Global.env () in
+  let () = Feedback.msg_info (Pp.str "param induction") in
   let _ = ETranslate.parametric_induction err translator env name mind in
   instances  
 

--- a/src/ePlugin.ml
+++ b/src/ePlugin.ml
@@ -338,16 +338,14 @@ let instantiate_parametric_modality err translator (name, n) ext =
   let name = Declarations.(mind.mind_packets.(0).mind_typename) in
   let induction_name = Nameops.add_suffix name "_ind_param" in
   let uctx = UState.context (Evd.evar_universe_context sigma) in
-  let _ = declare_axiom induction_name uctx (EConstr.to_constr sigma ind) in
+  let cst_ind = declare_axiom induction_name uctx (EConstr.to_constr sigma ind) in
   
-  let _ = Feedback.msg_info (Printer.pr_econstr ind_e) in
   let induction_name_e = Nameops.add_suffix induction_name "ᵉ" in
   let uctx = UState.context (Evd.evar_universe_context sigma) in
-  let _ = declare_constant_wo_ty induction_name_e uctx (EConstr.to_constr sigma ind_e) in
-
+  let cst_ind_e = declare_constant_wo_ty induction_name_e uctx (EConstr.to_constr sigma ind_e) in
   (* ********************* *)
 
-  instances  
+  ExtConstant (cst_ind, ConstRef cst_ind_e) :: instances  
 
 let try_instantiate_parametric_modality err translator (name, n) ext  =
   let module D = Declarations in 

--- a/src/ePlugin.mli
+++ b/src/ePlugin.mli
@@ -2,16 +2,8 @@ open Names
 open Libnames
 
 val translate : ?exn:reference -> ?names:Id.t list -> reference -> unit
-val ptranslate : ?exn:reference -> ?names:Id.t list -> reference -> unit
 
 val implement : ?exn:reference -> Id.t -> Constrexpr.constr_expr -> unit
-val pimplement : ?exn:reference -> reference -> unit
-
-val wtranslate : ?exn:reference -> ?names:Id.t list -> reference -> unit
-val wimplement : ?exn:reference -> reference -> unit
 
 (** Translate of list *)
 val list_translate : ?exn:reference -> reference list -> unit
-val list_ptranslate : ?exn:reference -> reference list -> unit
-val list_wtranslate : ?exn:reference -> reference list -> unit
-

--- a/src/eTranslate.ml
+++ b/src/eTranslate.ml
@@ -952,6 +952,7 @@ let param_instance_inductive err translator env (name,name_e,name_param) (one_d,
   let args = List.map (fun i -> Vars.lift 1 i) args in
   let inner_func = applist (ind_p, args) in
   let func = mkLambda (Anonymous, ty, mkApp (inner_func, [| mkRel 1 |])) in
+  
   let body = mkApp (param_constr, [|param_ty; func|]) in
   let param_instance = it_mkLambda_or_LetIn body ctx in
   let sigma,_ = Typing.type_of env sigma param_instance in

--- a/src/eTranslate.ml
+++ b/src/eTranslate.ml
@@ -135,15 +135,17 @@ let typeval_e = ConstructRef ((MutInd.make1 (make_kn "type"), 0), 1)
 let param_mod = MutInd.make1 (make_kn "ParamMod")
 let param_mod_e = MutInd.make1 (make_kn "ParamModᵉ")
 
-let default_mutind = MutInd.make1 (make_kn "effect_default")
-let default_mutind_e = MutInd.make1 (make_kn "effect_defaultᵒ")
-let default_mutind_r = MutInd.make1 (make_kn "effect_defaultᴿ")
 let param_cst = Constant.make1 (make_kn "param")
 let param_cst_e = Constant.make1 (make_kn "paramᵉ")
-let param_cst_r = Constant.make1 (make_kn "paramᴿ")
-
 let param_def = ConstRef param_cst
 let param_def_e = ConstRef param_cst_e
+
+let tm_exception = Constant.make1 (make_kn "Exception")
+let tm_exception_e = Constant.make1 (make_kn "Exceptionᵉ")
+
+let tm_raise = Constant.make1 (make_kn "raise")
+let tm_raise_e = Constant.make1 (make_kn "raiseᵉ")
+
 
 
 let name_errtype = Id.of_string "E"
@@ -1139,7 +1141,6 @@ and otranslate_param_type env param_env sigma (ind, ind_e) c = match EConstr.kin
    in
    let (sigma, uw) = otranslate_param_type nenv param_env sigma (ind, ind_e) u in
    let n = if is_ind_param then 3 else 2 in
-   let () = Feedback.msg_info (Pp.str "prev liftn") in
    let uw = Vars.liftn 1 (if is_ind_param then 4 else 3) uw in
    let uw = Vars.subst1 (mkApp (mkRel n, [| mkRel (n - 1) |])) uw in
    let ctx = param_top_decls nenv is_ind_param in
@@ -1314,6 +1315,9 @@ let catch_inductive err translator env name mind_d =
   let ind = mkIndU (ind, EInstance.make u) in
   let predicate = it_mkProd_or_LetIn ind arity in
   let predicate_args = one_d.mind_nrealargs in
+  let map n =
+    ()
+  in
   ()
 
 (** Locally extend a translator to fake an inductive definition *)

--- a/src/eTranslate.ml
+++ b/src/eTranslate.ml
@@ -1014,6 +1014,7 @@ let param_instance_inductive err translator env (name,name_e,name_param) (one_d,
 
   (sigma, instance_ty, param_instance)
 
+(*
 let catch_inductive err translator env name mind_d =
   let sigma = Evd.from_env env in 
   let (sigma, env) = make_context err translator env sigma in
@@ -1033,7 +1034,8 @@ let catch_inductive err translator env name mind_d =
     ()
   in
   ()
-
+ *)
+  
 let rec induction_generator sigma params_number constr_ty ind n_ind = 
 match EConstr.kind sigma constr_ty with
 | App (t, args) -> 
@@ -1105,8 +1107,6 @@ match EConstr.kind sigma constr_ty with
        Vars.substnl subst 0 bp
    in
    let t = mkLambda (na, Vars.lift 2 t, body) in
-   let () = Feedback.msg_info (Pp.str "parcial: " ++ Printer.pr_econstr t) in
-   let () = Feedback.msg_info (Pp.str "**********************************************************") in
    t
 | _ -> constr_ty
 
@@ -1203,8 +1203,6 @@ let parametric_induction err translator env name mind_d =
   let (_,_,l) = MutInd.repr3 name in
   let name_param = Nameops.add_suffix (Label.to_id l) "_param" in
   let name_param = MutInd.make1 (Lib.make_kn name_param) in
-  
-  let () = Feedback.msg_info (Pp.str "Name param: " ++ MutInd.print name_param) in
 
   let mind_d_param,_ = Inductive.lookup_mind_specif env.env_src (name_param, 0) in
   let one_d_param = mind_d_param.mind_packets.(n) in
@@ -1218,7 +1216,6 @@ let parametric_induction err translator env name mind_d =
   let ind_param_induction = Nameops.add_suffix one_d.mind_typename "_param_ind" in
   let sigma, (ind_param_induction, u) = 
     let cst = (Constant.make1 (Lib.make_kn ind_param_induction)) in
-    let () = Feedback.msg_info (Constant.print cst) in
     Evd.fresh_constant_instance env.env_src sigma cst
   in
   let cst = mkConstU (ind_param_induction, EInstance.make u) in
@@ -1255,7 +1252,6 @@ let parametric_induction err translator env name mind_d =
     let body_predicate = applist (mkRel predicate_rel, List.map (Vars.lift 1) pind_arity) in
     it_mkLambda_or_LetIn body_predicate predicate_ctx
   in
-  let _ = Feedback.msg_info (Pp.str "cst_pred " ++ Printer.pr_econstr cst_predicate) in
   let cst_predicate = Vars.lift (params_offset - 1) cst_predicate in
   let cst_params = Array.init (nparams + 1) (fun n -> mkRel (n + 1 + params_offset)) in
   let cst_arity = Array.init (nindices + 2) (fun n -> mkRel (n + 1)) in
@@ -1266,4 +1262,5 @@ let parametric_induction err translator env name mind_d =
   let trans_pred = it_mkLambda_or_LetIn app_cst induction_pr_tr_ctx in
   let e = get_exception env in
   let trans_pred = mkLambda_or_LetIn e trans_pred in
+  let sigma,_ = Typing.type_of env.env_src sigma trans_pred in
   (sigma, induction_pr, trans_pred)

--- a/src/eTranslate.ml
+++ b/src/eTranslate.ml
@@ -724,6 +724,7 @@ let rec otranslate_param env param_env sigma (ind, ind_e) c = match EConstr.kind
    let m = param_env_accum_up_to param_env n  in
    (sigma, mkRel m) 
 | Sort _ | Prod _ ->
+
    let (sigma, c_) = otranslate_param env param_env sigma (ind, ind_e) c in
    let c_ = param_lift param_env c_ in
    let (sigma, w) = otranslate_param_type env param_env sigma (ind, ind_e) c in
@@ -1205,7 +1206,5 @@ let parametric_induction err translator env name mind_d =
   let trans_pred = it_mkLambda_or_LetIn app_cst induction_pr_tr_ctx in
   let e = get_exception env in
   let trans_pred = mkLambda_or_LetIn e trans_pred in
-  let _ = Feedback.msg_info(Printer.pr_econstr induction_pr) in
-  let _ = Feedback.msg_info(Printer.pr_econstr trans_pred) in
   let sigma,_ = Typing.type_of env.env_src sigma trans_pred in
   (sigma, induction_pr, trans_pred, mkProd_or_LetIn e induction_pr_tr)

--- a/src/eTranslate.ml
+++ b/src/eTranslate.ml
@@ -554,7 +554,7 @@ let name_projection_translate sigma translation_function record_builder =
 let extend_inductive env mind0 mind =
   let open Univ in
   let univs = match mind0.mind_universes with
-  | Monomorphic_ind _ -> Monomorphic_ind UContext.empty
+  | Monomorphic_ind _ -> Monomorphic_ind ContextSet.empty
   | Polymorphic_ind _ -> Polymorphic_ind AUContext.empty
   | Cumulative_ind _ -> Polymorphic_ind AUContext.empty (** FIXME *)
   in
@@ -680,7 +680,7 @@ let translate_inductive err translator env _ mind0 (mind : Entries.mutual_induct
   let params = List.map to_local_entry params in
   let uctx = UState.context (Evd.evar_universe_context sigma) in
   let univs = match mind.mind_entry_universes with
-  | Monomorphic_ind_entry _ -> Monomorphic_ind_entry uctx
+  | Monomorphic_ind_entry _ -> Monomorphic_ind_entry (Univ.ContextSet.of_context uctx)
   | Polymorphic_ind_entry _ -> Polymorphic_ind_entry uctx
   | Cumulative_ind_entry _ -> Polymorphic_ind_entry uctx (** FIXME *)
   in
@@ -893,7 +893,7 @@ let param_mutual_inductive err translator env (block, block_e) mind_d mind_e =
   let params = List.map to_local_entry params in
   let uctx = UState.context (Evd.evar_universe_context sigma) in
   let univs = match mind_e.mind_entry_universes with
-  | Monomorphic_ind_entry _ -> Monomorphic_ind_entry uctx
+  | Monomorphic_ind_entry _ -> Monomorphic_ind_entry (Univ.ContextSet.of_context uctx)
   | Polymorphic_ind_entry _ -> Polymorphic_ind_entry uctx
   | Cumulative_ind_entry _ -> Polymorphic_ind_entry uctx (** FIXME *)
   in

--- a/src/eTranslate.mli
+++ b/src/eTranslate.mli
@@ -46,26 +46,6 @@ val translate_inductive :
   effect -> translator -> Environ.env -> MutInd.t -> Declarations.mutual_inductive_body ->
     Entries.mutual_inductive_entry -> Entries.mutual_inductive_entry
 
-val ptranslate :
-  effect -> translator -> Environ.env -> Evd.evar_map -> EConstr.t -> Evd.evar_map * EConstr.t
-
-val ptranslate_type :
-  effect -> translator -> Environ.env -> Evd.evar_map -> EConstr.t -> Evd.evar_map * EConstr.t
-
-val ptranslate_inductive :
-  effect -> translator -> Environ.env -> MutInd.t -> Declarations.mutual_inductive_body ->
-    Entries.mutual_inductive_entry -> Entries.mutual_inductive_entry
-
-val wtranslate :
-  effect -> translator -> Environ.env -> Evd.evar_map -> EConstr.t -> Evd.evar_map * EConstr.t
-
-val wtranslate_type :
-  effect -> translator -> Environ.env -> Evd.evar_map -> EConstr.t -> Evd.evar_map * EConstr.t
-
-val wtranslate_inductive :
-  effect -> translator -> Environ.env -> MutInd.t -> Declarations.mutual_inductive_body ->
-    Entries.mutual_inductive_entry -> Entries.mutual_inductive_entry
-
 val param_mutual_inductive :
   effect -> translator -> Environ.env -> MutInd.t * MutInd.t -> Declarations.mutual_inductive_body -> 
     Entries.mutual_inductive_entry -> Entries.mutual_inductive_entry 
@@ -74,11 +54,5 @@ val param_instance_inductive :
   effect -> translator -> Environ.env -> MutInd.t * MutInd.t * MutInd.t-> 
     Declarations.one_inductive_body * int -> Evd.evar_map * EConstr.t * EConstr.t
 
-val wparam_mutual_inductive :
-  effect -> translator -> Environ.env -> MutInd.t-> Declarations.mutual_inductive_body -> 
-    Entries.mutual_inductive_entry -> Entries.mutual_inductive_entry 
-
-val param_definition :
-  effect -> translator -> Environ.env -> MutInd.t * MutInd.t -> 
-    Declarations.mutual_inductive_body -> 
-    Entries.mutual_inductive_entry -> Evd.evar_map * EConstr.t list
+val parametric_induction :
+  effect -> translator -> Environ.env -> MutInd.t -> Declarations.mutual_inductive_body -> unit

--- a/src/eTranslate.mli
+++ b/src/eTranslate.mli
@@ -31,6 +31,10 @@ val param_mod:   Names.MutInd.t
 val param_mod_e: Names.MutInd.t
 val param_cst:   Names.Constant.t
 val param_cst_e: Names.Constant.t
+val tm_exception: Names.Constant.t
+val tm_exception_e: Names.Constant.t
+val tm_raise: Names.Constant.t
+val tm_raise_e: Names.Constant.t
 
 val translate :
   effect -> translator -> Environ.env -> Evd.evar_map -> EConstr.t -> Evd.evar_map * EConstr.t

--- a/src/eTranslate.mli
+++ b/src/eTranslate.mli
@@ -55,4 +55,5 @@ val param_instance_inductive :
     Declarations.one_inductive_body * int -> Evd.evar_map * EConstr.t * EConstr.t
 
 val parametric_induction :
-  effect -> translator -> Environ.env -> MutInd.t -> Declarations.mutual_inductive_body -> unit
+  effect -> translator -> Environ.env -> MutInd.t -> Declarations.mutual_inductive_body -> 
+    Evd.evar_map * EConstr.t * EConstr.t

--- a/src/eTranslate.mli
+++ b/src/eTranslate.mli
@@ -56,4 +56,4 @@ val param_instance_inductive :
 
 val parametric_induction :
   effect -> translator -> Environ.env -> MutInd.t -> Declarations.mutual_inductive_body -> 
-    Evd.evar_map * EConstr.t * EConstr.t
+    Evd.evar_map * EConstr.t * EConstr.t * EConstr.t

--- a/src/eUtil.ml
+++ b/src/eUtil.ml
@@ -215,7 +215,7 @@ let process_inductive mib =
   | Cumulative_ind cumi ->
     let auctx = Univ.ACumulativityInfo.univ_context cumi in
     let auctx = Univ.AUContext.repr auctx in
-    Cumulative_ind_entry (Universes.univ_inf_ind_from_universe_context auctx)
+    Cumulative_ind_entry (Univ.CumulativityInfo.from_universe_context auctx)
   in
   let map mip =
     let arity, template = refresh_polymorphic_type_of_inductive (mib,mip) in

--- a/src/g_exception.ml4
+++ b/src/g_exception.ml4
@@ -14,30 +14,10 @@ VERNAC COMMAND EXTEND EffectTranslation CLASSIFIED AS SIDEFF
 | [ "Effect" "Translate" global(gr) "using" global(exn) ] ->
   [ EPlugin.translate ~exn gr ]
 
-| [ "Parametricity" "Translate" global(gr) ] ->
-  [ EPlugin.ptranslate gr ]
-| [ "Parametricity" "Translate" global(gr) "as" ne_ident_list(names) ] ->
-  [ EPlugin.ptranslate ~names gr ]
-| [ "Parametricity" "Translate" global(gr) "using" global(exn) ] ->
-  [ EPlugin.ptranslate ~exn gr ]
-
-| [ "Weakly" "Translate" global(gr) ] ->
-  [ EPlugin.wtranslate gr ]
-| [ "Weakly" "Translate" global(gr) "using" global(exn)] ->
-  [ EPlugin.wtranslate ~exn gr ]
-
 | [ "Effect" "List" "Translate" global_list(gr) ] ->
   [ EPlugin.list_translate gr ]
 | [ "Effect" "List" "Translate" global_list(gr) "using" global(exn) ] ->
   [ EPlugin.list_translate ~exn gr ]
-| [ "Weakly" "List" "Translate" global_list(gr) ] ->
-  [ EPlugin.list_wtranslate gr ]
-| [ "Weakly" "List" "Translate" global_list(gr) "using" global(exn) ] ->
-  [ EPlugin.list_wtranslate ~exn gr ]
-| [ "Parametricity" "List" "Translate" global_list(gr) ] ->
-  [ EPlugin.list_ptranslate gr ]
-| [ "Parametricity" "List" "Translate" global_list(gr) "using" global(exn) ] ->
-  [ EPlugin.list_ptranslate ~exn gr ]
 
 END
 
@@ -49,14 +29,5 @@ VERNAC COMMAND EXTEND EffectImplementation CLASSIFIED BY classify_impl
 | [ "Effect" "Definition" ident(id) ":" lconstr(typ) "using" reference(exn) ] ->
   [ EPlugin.implement ~exn id typ ]
 
-| [ "Weakly" "Definition" global(gr) ] ->
-  [ EPlugin.wimplement gr ]
-| [ "Weakly" "Definition" global(gr)  "using" reference(exn) ] ->
-  [ EPlugin.wimplement ~exn gr ]
-
-| [ "Parametricity" "Definition" global(gr) ] ->
-  [ EPlugin.pimplement gr ]
-| [ "Parametricity" "Definition" global(gr) "using" reference(exn) ] ->
-  [ EPlugin.pimplement ~exn gr ]
 END
 

--- a/tests/cast.v
+++ b/tests/cast.v
@@ -14,7 +14,7 @@ Effect List Translate eq eq_ind eq_rect eq_rec.
 Effect List Translate nat nat_rect nat_rec. 
 Effect List Translate list list_rect.
 Effect List Translate length eq_sym eq_trans f_equal.
-Effect List Translate sig sig_rect sig_rec.
+Effect List Translate sig sig_rect sig_rec proj1_sig.
 Effect List Translate prod prod_rect.
 
 (* basic inversion lemmas for nat *)
@@ -51,11 +51,13 @@ induction x.
 Defined.
 Effect List Translate Decidable_eq_nat.
 
-Instance EqDecidable_nat : EqDecidable nat := 
-  { eq_dec := Decidable_eq_nat }.
-
+Instance EqDecidable_nat : EqDecidable nat := { eq_dec := Decidable_eq_nat }.
 Effect List Translate EqDecidable_nat.
 
+Instance FalseDecidable : Decidable False.
+Proof. right; intros a; assumption. Defined.
+Effect Translate FalseDecidable.
+  
 Notation " ( x ; p ) " := (exist _ x p).
 
 Definition cast (A:Type) (P : A -> Prop)
@@ -64,8 +66,12 @@ Definition cast (A:Type) (P : A -> Prop)
   - exact (a ; a0).
   - exact (raise _ e).
 Defined. 
-
 Effect Translate cast.
+
+Definition forbidden_cast: False := proj2_sig (cast nat (fun _ => False) 0).
+Fail Effect Translate proj2_sig. 
+(* Due to elimination from Prop to Type *)
+(* ==> Fail Effect Translate forbidden_cast. *)
 
 Definition list2_to_pair {A} : {l : list A | length l = 2} -> A * A.
 Proof.

--- a/tests/list_theorem.v
+++ b/tests/list_theorem.v
@@ -1,9 +1,21 @@
 Require Import Weakly.Effects.
 
-Effect Definition e: Exception. Admitted.
+Effect Definition e: Exception. Admitted. 
 
+Inductive nat' (E: Type): Type :=
+| O': nat' E
+| S': nat' E -> nat' E
+| nat_exc: E -> nat' E.
+
+Inductive nat_param' (E: Type): nat' E -> Prop :=
+| O'_param: nat_param' E (O' E)
+| S'_param: forall n, nat_param' E n -> nat_param' E (S' E n). 
+          
 Effect List Translate nat bool list.
 Effect List Translate False le lt gt eq not and or.
+
+Definition g: forall e, nat := fun e => raise nat e.
+Effect Translate g. Print gᵉ.
 
 Scheme eqᵒ_rect := Induction for eqᵒ Sort Type.
 Scheme eqᵒ_ind := Induction for eqᵒ Sort Prop.
@@ -99,6 +111,9 @@ Proof.
   - exact (Falseᵒ E).
 Defined. Print list_param_deepᵉ.
 
+Effect Definition param_correctness: forall (A: Type) (H: ParamMod A) e, param (raise A e) -> False.
+
+
 Effect Definition head_empty_list_no_error: forall A {H: ParamMod A } (l: list A),
     length l > 0 -> list_param_deep A H l -> head l <> raise _ e.
 Proof.
@@ -107,5 +122,16 @@ Proof.
   - inversion Hlength.
   - inversion list_deep_param.
     inversion Hhead. simpl in *. subst. 
-Abort.
-    
+Abort.   
+
+Inductive vec (A: Type) : nat -> Type :=
+| vnil: vec A 0
+| vcons: forall n, A -> vec A n -> vec A (S n).
+
+Effect Translate vec.
+
+Effect Definition raise_correctnes: forall A n, param (raise (vec A n) e) -> False.
+Proof.
+  simpl. intros E A n Hn.
+  inversion Hn.
+  Show Proof.

--- a/tests/list_theorem.v
+++ b/tests/list_theorem.v
@@ -1,0 +1,111 @@
+Require Import Weakly.Effects.
+
+Effect Definition e: Exception. Admitted.
+
+Effect List Translate nat bool list.
+Effect List Translate False le lt gt eq not and or.
+
+Scheme eqᵒ_rect := Induction for eqᵒ Sort Type.
+Scheme eqᵒ_ind := Induction for eqᵒ Sort Prop.
+Scheme listᵒ_rect := Induction for listᵒ Sort Type.
+Scheme listᵒ_ind := Induction for listᵒ Sort Prop.
+
+Scheme leᵒ_ind := Induction for leᵒ Sort Prop.
+
+Fixpoint length {A: Type} (l: list A): nat :=
+  match l with
+  | nil => 0
+  | cons _ l' => S (length l')
+  end.
+
+Definition head {A: Type} (l: list A): A :=
+  match l with
+  | nil => raise A e
+  | cons a _ => a
+  end.
+
+Definition tail {A: Type} (l: list A): list A := 
+  match l with
+  | nil => raise (list A) e
+  | cons _ l' => l'
+  end.
+
+Effect List Translate length head tail.
+
+(* Expected theorem *)
+Effect Definition non_empty_list_distinct_error: forall (A: Type) (l: list A),
+    length l > 0 -> tail l <> raise _ e.
+Proof.
+  simpl; intros E A l Hl Htail.
+  induction l; simpl in *.
+  - inversion Hl.
+  - destruct l; try inversion Htail.
+    + inversion Hl. inversion H1.
+  - inversion Hl.
+Defined.
+
+(* Under this translation is not allowed *)
+Definition non_valid_theorem: forall (A: Type) (l: list A),
+    length l > 0 -> tail l = raise _ e := raise _ e.
+Fail Effect Translate non_valid_theorem.
+
+Effect Definition non_empty_list_distinct_error_param: forall (A: Type) (l: list A),
+    length l > 0 -> param l -> tail l <> raise _ e.
+Proof.
+  simpl; intros E A l Hl Hparam Htail.
+  induction Hparam.
+  - inversion Hl.
+  - destruct l; inversion Htail.
+    +  inversion Hl. inversion H1. 
+Defined.
+
+(* Not true for head *)
+Effect Definition non_empty_list_distinct_error_param: forall (A: Type) (l: list A),
+    length l > 0 -> param l -> head l = raise _ e \/ head l <> raise _ e.
+Proof.
+  simpl; intros E A l Hl Hparam.
+  destruct l eqn: Hlist.
+  - inversion Hl.
+  - simpl in *. subst.
+Abort.
+
+Effect Definition length_implies_param_list: forall (A: Type) (l: list A),
+    length l > 0 -> param l.
+Proof.
+  intros E A l H.
+  induction l. 
+  - constructor. 
+  - destruct l.
+    + constructor. constructor.
+    + simpl in *. constructor. apply IHl.
+      inversion H.
+      apply H1.
+    + simpl in H. inversion H; subst. inversion H1.
+  - inversion H.
+Defined.
+
+Effect Definition param_error_false: forall A, param (raise (list A) e) -> False.
+Proof.
+  simpl. intros E A Hp.
+  inversion Hp.
+Defined.
+
+Effect Definition list_param_deep: forall {A: Type} {H: ParamMod A} (l: list A), Prop.
+Proof.
+  intros E A H l.
+  destruct l.
+  - exact (list_param E A (nilᵉ E A)).
+  - exact (paramᵉ e0 /\ (list_param E A (consᵉ E A e0 l))).
+  - exact (Falseᵒ E).
+Defined. Print list_param_deepᵉ.
+
+Effect Definition head_empty_list_no_error: forall A {H: ParamMod A } (l: list A),
+    length l > 0 -> list_param_deep A H l -> head l <> raise _ e.
+Proof.
+  intros E A A_param l Hlength list_deep_param Hhead.
+  destruct l.
+  - inversion Hlength.
+  - inversion list_deep_param.
+    inversion Hhead. simpl in *. subst. 
+Abort.
+    

--- a/tests/list_theorem.v
+++ b/tests/list_theorem.v
@@ -10,7 +10,8 @@ Inductive nat' (E: Type): Type :=
 Inductive nat_param' (E: Type): nat' E -> Prop :=
 | O'_param: nat_param' E (O' E)
 | S'_param: forall n, nat_param' E n -> nat_param' E (S' E n). 
-          
+
+
 Effect List Translate nat bool list.
 Effect List Translate False le lt gt eq not and or.
 
@@ -111,8 +112,8 @@ Proof.
   - exact (Falseᵒ E).
 Defined. Print list_param_deepᵉ.
 
-Effect Definition param_correctness: forall (A: Type) (H: ParamMod A) e, param (raise A e) -> False.
-
+Effect Definition param_correctnes: forall (A: Type) (H: ParamMod A) e, param (raise A e) -> False.
+Proof. Admitted.
 
 Effect Definition head_empty_list_no_error: forall A {H: ParamMod A } (l: list A),
     length l > 0 -> list_param_deep A H l -> head l <> raise _ e.
@@ -121,17 +122,6 @@ Proof.
   destruct l.
   - inversion Hlength.
   - inversion list_deep_param.
-    inversion Hhead. simpl in *. subst. 
-Abort.   
-
-Inductive vec (A: Type) : nat -> Type :=
-| vnil: vec A 0
-| vcons: forall n, A -> vec A n -> vec A (S n).
-
-Effect Translate vec.
-
-Effect Definition raise_correctnes: forall A n, param (raise (vec A n) e) -> False.
-Proof.
-  simpl. intros E A n Hn.
-  inversion Hn.
-  Show Proof.
+    inversion Hhead. simpl in *; subst. exact (param_correctnesᵉ E A A_param (eᵉ E) H).
+  - inversion Hlength.
+Defined.

--- a/tests/stress_translation.v
+++ b/tests/stress_translation.v
@@ -1,10 +1,18 @@
 Require Import Weakly.Effects.
 
-Inductive empty: Type := . Print sigT.
+Inductive empty: Type := . 
 
 Inductive vec (A: Type): nat -> Type :=
 | vnil: vec A 0
 | vconst: forall n, A -> vec A n -> vec A (S n).
+
+
+Module UsingType.
+
+Effect List Translate empty unit bool nat list vec sum sig sigT using unit.
+Effect List Translate False True and or ex eq using unit.
+
+End UsingType.
 
 Effect List Translate empty unit bool nat list vec sum sig sigT.
 Effect List Translate False True and or ex eq.

--- a/theories/Effects.v
+++ b/theories/Effects.v
@@ -155,7 +155,7 @@ Definition type@{i j} (E: Type@{i}) :=
 Definition sTypeVal@{i j} (E: Type@{i}) (A: Type@{j}) (f: E -> A): type@{i j} E :=
   sortType E A f.
 Definition sTypeErr@{i j} (E: Type@{i}) (e: E): type@{i j} E :=
-  sortErr E e.
+  sortErr@{i j} E e.
 
 Definition prop@{i} (E: Type@{i}) :=
   sort@{i Set} E.

--- a/theories/Effects.v
+++ b/theories/Effects.v
@@ -50,13 +50,20 @@ match A with
 | pTypeErr _ e => True
 end.
 
+Axiom Exception: Type.
+Definition Exceptionᵉ (E: Type): type E := TypeVal E E (fun e => e).
+Axiom raise: forall (A: Type), Exception -> A. 
+Definition raiseᵉ (E: Type) (A: @El E (@Typeᵉ E)) (e: @El E (Exceptionᵉ E)) := Err A e.
+
 Set Primitive Projections.
 Class ParamMod (A: Type) := {
-  param: A -> Prop
+  param: A -> Prop;
+  param_correct: forall e, param (raise A e) -> False
 }.
 
 Class ParamModᵉ (E: Type) (A: @El E (@Typeᵉ E)) := {
-  paramᵉ: @El E A -> Prop
+  paramᵉ: @El E A -> Prop;
+  (* param_correctᵉ: forall e, paramᵉ (raiseᵉ E A e) -> False *)
 }.
 Unset Primitive Projections.
 
@@ -64,10 +71,6 @@ Unset Primitive Projections.
     Providing Exception and raise construction to work on the source theory. 
     This terms only reify the underlying exceptinal Type 
 *)
-Axiom Exception: Type.
-Definition Exceptionᵉ (E: Type): type E := TypeVal E E (fun e => e).
-Axiom raise: forall (A: Type), Exception -> A. 
-Definition raiseᵉ (E: Type) (A: @El E (@Typeᵉ E)) (e: @El E (Exceptionᵉ E)) := Err A e.
 
 (******************************)
 (*** Test handling of sorts ***)

--- a/theories/Effects.v
+++ b/theories/Effects.v
@@ -60,6 +60,14 @@ Class ParamModᵉ (E: Type) (A: @El E (@Typeᵉ E)) := {
 }.
 Unset Primitive Projections.
 
+(** 
+    Providing Exception and raise construction to work on the source theory. 
+    This terms only reify the underlying exceptinal Type 
+*)
+Axiom Exception: Type.
+Definition Exceptionᵉ (E: Type): type E := TypeVal E E (fun e => e).
+Axiom raise: forall (A: Type), Exception -> A. 
+Definition raiseᵉ (E: Type) (A: @El E (@Typeᵉ E)) (e: @El E (Exceptionᵉ E)) := Err A e.
 
 (******************************)
 (*** Test handling of sorts ***)

--- a/theories/Effects.v
+++ b/theories/Effects.v
@@ -55,6 +55,8 @@ Definition Exceptionᵉ (E: Type): type E := TypeVal E E (fun e => e).
 Axiom raise: forall (A: Type), Exception -> A. 
 Definition raiseᵉ (E: Type) (A: @El E (@Typeᵉ E)) (e: @El E (Exceptionᵉ E)) := Err A e.
 
+Inductive Falseᵉ: Prop :=.
+
 Set Primitive Projections.
 Class ParamMod (A: Type) := {
   param: A -> Prop;
@@ -63,7 +65,7 @@ Class ParamMod (A: Type) := {
 
 Class ParamModᵉ (E: Type) (A: @El E (@Typeᵉ E)) := {
   paramᵉ: @El E A -> Prop;
-  (* param_correctᵉ: forall e, paramᵉ (raiseᵉ E A e) -> False *)
+  (* param_correctᵉ: forall e, paramᵉ (raiseᵉ E A e) -> (Falseᵉ E) *)
 }.
 Unset Primitive Projections.
 

--- a/theories/Effects.v
+++ b/theories/Effects.v
@@ -51,11 +51,11 @@ match A with
 end.
 
 Set Primitive Projections.
-Monomorphic Class ParamMod (A: Type) := {
+Class ParamMod (A: Type) := {
   param: A -> Prop
 }.
 
-Monomorphic Class ParamModᵉ (E: Type) (A: @El E (@Typeᵉ E)) := {
+Class ParamModᵉ (E: Type) (A: @El E (@Typeᵉ E)) := {
   paramᵉ: @El E A -> Prop
 }.
 Unset Primitive Projections.


### PR DESCRIPTION
Now for every (non-mutual) inductive, the translation generates an induction principle for Prop which ask for a parametric instance of the term and without a case for the default constructor. The principle is generated by an induction in the parametric instance.